### PR TITLE
Update install steps for phantomjs

### DIFF
--- a/MacOS-InstallSteps.md
+++ b/MacOS-InstallSteps.md
@@ -130,7 +130,8 @@ Click on **About your application's environment** to verify your Ruby and Rails 
 
 #### Install PhantomJS
 ~~~
-$ brew install phantomjs
+$ brew tap homebrew/cask
+$ brew cask install phantomjs
 ~~~
 Verify that PhantomJS is now installed.
 ~~~


### PR DESCRIPTION
The previous command ($ brew install phantomjs) resulted in an error: 

No available formula with the name "phantomjs" It was migrated from homebrew/core to homebrew/cask.

You can access it again by running:  brew tap homebrew/cask
And then you can install it by running:  brew cask install phantomjs